### PR TITLE
Fixes height of images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ if the cost exceeds the limit.
   to know if a pull request adds a massive dependency.
 
 <p align="center">
-  <img src="./img/example.png" alt="Size Limit CLI" width="738" height="434">
+  <img src="./img/example.png" alt="Size Limit CLI" width="738" >
 </p>
 
 With `--why`, Size Limit can tell you *why* your library has this size
@@ -24,7 +24,7 @@ and show the real cost of all your internal dependencies.
 
 <p align="center">
   <img src="./img/why.png" alt="Bundle Analyzer example"
-       width="650" height="335">
+       width="650">
 </p>
 
 <p align="center">


### PR DESCRIPTION
Remove fixed `height` props from images to make its look ok on small screens

Before:
![image](https://user-images.githubusercontent.com/9060346/56944928-f7680300-6b2d-11e9-9aaf-91b281db1230.png)

After:
![image](https://user-images.githubusercontent.com/9060346/56944982-21b9c080-6b2e-11e9-9300-64362c80ad92.png)
